### PR TITLE
Add build script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node ./server.js --production",
     "local:build": "webpack --env.NODE_ENV=development --mode=development",
+    "build": "exit 0",
     "unit-test": "jest",
     "int-test": "jest --testRegex=.*\\.ispec\\.js$",
     "test": "jest --testRegex=.*\\.i?spec\\.js$",


### PR DESCRIPTION
The default Node template for Azure Pipelines calls a step called 'build'. Create a script that simply returns a zero exit code so that the default build completes successfully.